### PR TITLE
Fix budgets

### DIFF
--- a/src/main/java/com/bloxbean/cardano/aiken/tx/evaluator/TxEvaluator.java
+++ b/src/main/java/com/bloxbean/cardano/aiken/tx/evaluator/TxEvaluator.java
@@ -143,7 +143,7 @@ public class TxEvaluator {
 
     private static InitialBudgetConfig.InitialBudgetByValue getDefaultInitialBudgetConfig() {
         InitialBudgetConfig.InitialBudgetByValue initialBudgetConfig = new InitialBudgetConfig.InitialBudgetByValue();
-        initialBudgetConfig.mem = 10000000;
+        initialBudgetConfig.mem = 14000000L;
         initialBudgetConfig.cpu = 10000000000L;
 
         return initialBudgetConfig;

--- a/src/test/java/com/bloxbean/cardano/aiken/tx/evaluator/EvalPhaseTwoTest.java
+++ b/src/test/java/com/bloxbean/cardano/aiken/tx/evaluator/EvalPhaseTwoTest.java
@@ -30,7 +30,7 @@ public class EvalPhaseTwoTest {
         slotConfig.slot_length = 1000;
 
         InitialBudgetConfig.InitialBudgetByValue initialBudgetConfig = new InitialBudgetConfig.InitialBudgetByValue();
-        initialBudgetConfig.mem = 16000000L;
+        initialBudgetConfig.mem = 14000000L;
         initialBudgetConfig.cpu = 10000000000L;
 
         for (int i=0; i<30; i++) { //Looping to check any occasional jvm crash error
@@ -52,7 +52,7 @@ public class EvalPhaseTwoTest {
         slotConfig.slot_length = 1000;
 
         InitialBudgetConfig.InitialBudgetByValue initialBudgetConfig = new InitialBudgetConfig.InitialBudgetByValue();
-        initialBudgetConfig.mem = 16000000L;
+        initialBudgetConfig.mem = 14000000L;
         initialBudgetConfig.cpu = 10000000000L;
 
         for (int i=0; i<30; i++) { //Looping to check any occasional jvm crash error


### PR DESCRIPTION
Apparently it is 
mem = 14000000L

on main-net, not 16000000L

This raises interesting question if we should be keeping default or rather read default from Aiken... all defaults.

data source: https://cexplorer.io/params